### PR TITLE
Disable doctests in all sub-crates

### DIFF
--- a/sv-parser-error/Cargo.toml
+++ b/sv-parser-error/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 description = "Helper crate of sv-parser"
 edition = "2018"
 
+[lib]
+doctest = false
+
 [package.metadata.release]
 disable-tag = true
 

--- a/sv-parser-macros/Cargo.toml
+++ b/sv-parser-macros/Cargo.toml
@@ -15,6 +15,7 @@ disable-tag = true
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 quote = "1.0.0"

--- a/sv-parser-parser/Cargo.toml
+++ b/sv-parser-parser/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 description = "Helper crate of sv-parser"
 edition = "2018"
 
+[lib]
+doctest = false
+
 [package.metadata.release]
 disable-tag = true
 

--- a/sv-parser-pp/Cargo.toml
+++ b/sv-parser-pp/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 description = "Helper crate of sv-parser"
 edition = "2018"
 
+[lib]
+doctest = false
+
 [package.metadata.release]
 disable-tag = true
 

--- a/sv-parser-syntaxtree/Cargo.toml
+++ b/sv-parser-syntaxtree/Cargo.toml
@@ -11,6 +11,9 @@ description = "Helper crate of sv-parser"
 edition = "2018"
 build = "build.rs"
 
+[lib]
+doctest = false
+
 [package.metadata.release]
 disable-tag = true
 

--- a/sv-parser/Cargo.toml
+++ b/sv-parser/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 description = "SystemVerilog parser library fully complient with IEEE 1800-2017"
 edition = "2018"
 
+[lib]
+doctest = false
+
 [package.metadata.release]
 pre-release-replacements = [
     {file = "../README.md", search = "sv-parser = \"[a-z0-9\\.-]+\"", replace = "sv-parser = \"{{version}}\""},


### PR DESCRIPTION
There are no doc tests in this crate as of now. Due to the size of some of the crates, this causes `cargo test` to hang trying to search for nonexistent doc tests. Disabling doc tests would help when iterating with this code and unit tests.