### PR TITLE
Refactoring: Add Eq and PartialEq to Define, DefineText and template type alias for Defines

### DIFF
--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -13,6 +13,7 @@ use sv_parser_syntaxtree::{
     IncludeCompilerDirective, Locate, NodeEvent, RefNode, SourceDescription, TextMacroUsage,
     WhiteSpace,
 };
+use std::collections::hash_map::RandomState;
 
 const RECURSIVE_LIMIT: usize = 64;
 
@@ -114,11 +115,11 @@ impl DefineText {
     }
 }
 
-pub type Defines = HashMap<String, Option<Define>>;
+pub type Defines<V=RandomState> = HashMap<String, Option<Define>, V>;
 
 pub fn preprocess<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     path: T,
-    pre_defines: &HashMap<String, Option<Define>, V>,
+    pre_defines: &Defines<V>,
     include_paths: &[U],
     strip_comments: bool,
     ignore_include: bool,
@@ -173,7 +174,7 @@ impl<'a> SkipNodes<'a> {
 pub fn preprocess_str<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     s: &str,
     path: T,
-    pre_defines: &HashMap<String, Option<Define>, V>,
+    pre_defines: &Defines<V>,
     include_paths: &[U],
     ignore_include: bool,
     strip_comments: bool,

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -81,14 +81,14 @@ impl PreprocessedText {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Define {
     identifier: String,
     arguments: Vec<(String, Option<String>)>,
     text: Option<DefineText>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineText {
     text: String,
     origin: Option<(PathBuf, Range)>,

--- a/sv-parser/src/lib.rs
+++ b/sv-parser/src/lib.rs
@@ -1,7 +1,6 @@
 #![recursion_limit = "256"]
 
 use nom_greedyerror::error_position;
-use std::collections::HashMap;
 use std::fmt;
 use std::hash::BuildHasher;
 use std::path::{Path, PathBuf};
@@ -127,7 +126,7 @@ impl<'a> IntoIterator for &'a SyntaxTree {
 
 pub fn parse_sv<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     path: T,
-    pre_defines: &HashMap<String, Option<Define>, V>,
+    pre_defines: &Defines<V>,
     include_paths: &[U],
     ignore_include: bool,
     allow_incomplete: bool,
@@ -178,7 +177,7 @@ pub fn parse_sv_pp(
 pub fn parse_sv_str<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     s: &str,
     path: T,
-    pre_defines: &HashMap<String, Option<Define>, V>,
+    pre_defines: &Defines<V>,
     include_paths: &[U],
     ignore_include: bool,
     allow_incomplete: bool,
@@ -197,7 +196,7 @@ pub fn parse_sv_str<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
 
 pub fn parse_lib<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     path: T,
-    pre_defines: &HashMap<String, Option<Define>, V>,
+    pre_defines: &Defines<V>,
     include_paths: &[U],
     ignore_include: bool,
     allow_incomplete: bool,
@@ -209,7 +208,7 @@ pub fn parse_lib<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
 pub fn parse_lib_str<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     s: &str,
     path: T,
-    pre_defines: &HashMap<String, Option<Define>, V>,
+    pre_defines: &Defines<V>,
     include_paths: &[U],
     ignore_include: bool,
     allow_incomplete: bool,
@@ -300,6 +299,7 @@ macro_rules! unwrap_locate {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test() {


### PR DESCRIPTION
This is just a refactoring PR and does two things: 
- [x] Derives `Eq` and `PartialEq` for Define and DefineText. I'm adding some unit tests in svls which benefit from this.
- [x] Templates the type alias `Defines` and replaces the usage of `HashMap<String, Option<Define>>` with the type alias. This makes it easier to use the type alias `Defines` in other crates like svls.