### PR TITLE
fix(sv-parser-pp): increase recursion limit to allow docs to build

### DIFF
--- a/sv-parser-pp/src/lib.rs
+++ b/sv-parser-pp/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![recursion_limit = "256"]
 
 pub mod preprocess;
 pub mod range;


### PR DESCRIPTION
Fixes #45
