### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
     let includes: Vec<PathBuf> = Vec::new();
 
     // Parse
-    let result = parse_sv(&path, &defines, &includes, false);
+    let result = parse_sv(&path, &defines, &includes, false, false);
 
     if let Ok((syntax_tree, _)) = result {
         // &SyntaxTree is iterable


### PR DESCRIPTION
Set `allow_complete` argument of `parse_sv` function as `false` so that it compiles with latest version (0.11.3).