### PR TITLE
Predefine `SV_COV_*` constants required by clause 40.3.1

### DIFF
--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -220,6 +220,35 @@ pub fn preprocess_str<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     let mut last_item_line = None;
     let mut last_include_line = None;
 
+    // IEEE1800-2017 Clause 40.3.1, page 1121
+    // The following predefined `define macros represent basic real-time
+    // coverage capabilities accessible directly from SystemVerilog:
+    let sv_cov_pre_defines = [
+        ("SV_COV_START",        "0"),
+        ("SV_COV_STOP",         "1"),
+        ("SV_COV_RESET",        "2"),
+        ("SV_COV_CHECK",        "3"),
+        ("SV_COV_MODULE",       "10"),
+        ("SV_COV_HIER",         "11"),
+        ("SV_COV_ASSERTION",    "20"),
+        ("SV_COV_FSM_STATE",    "21"),
+        ("SV_COV_STATEMENT",    "22"),
+        ("SV_COV_TOGGLE",       "23"),
+        ("SV_COV_OVERFLOW",     "-2"),
+        ("SV_COV_ERROR",        "-1"),
+        ("SV_COV_NOCOV",        "0"),
+        ("SV_COV_OK",           "1"),
+        ("SV_COV_PARTIAL",      "2"),
+    ];
+    for (k, v) in sv_cov_pre_defines {
+        let define = Define {
+            identifier: k.to_string(),
+            arguments: Vec::new(),
+            text: Some(DefineText {text: v.to_string(), origin: None}),
+        };
+        defines.insert(k.to_string(), Some(define));
+    }
+
     for (k, v) in pre_defines {
         defines.insert(k.clone(), (*v).clone());
     }
@@ -1136,7 +1165,6 @@ mod tests {
     } // }}}
 
     #[test]
-    #[ignore = "Coverage constants not implemented, yet."]
     fn coverage_constants() { // {{{
         let (ret, _) = preprocess_usualargs("coverage_constants.sv").unwrap();
         assert_eq!(

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -1136,6 +1136,16 @@ mod tests {
     } // }}}
 
     #[test]
+    #[ignore = "Coverage constants not implemented, yet."]
+    fn coverage_constants() { // {{{
+        let (ret, _) = preprocess_usualargs("coverage_constants.sv").unwrap();
+        assert_eq!(
+            ret.text(),
+            testfile_contents("expected/coverage_constants.sv")
+        );
+    } // }}}
+
+    #[test]
     fn default_nettype() { // {{{
         let (ret, _) = preprocess_usualargs("default_nettype.sv").unwrap();
         assert_eq!(

--- a/sv-parser-pp/testcases/coverage_constants.sv
+++ b/sv-parser-pp/testcases/coverage_constants.sv
@@ -1,0 +1,26 @@
+// IEEE1800-2017 Clause 40.3.1
+// The following predefined `define macros represent basic real-time coverage
+// capabilities accessible directly from SystemVerilog:
+
+// Coverage control
+localparam int SV_COV_START = `SV_COV_START; // 0
+localparam int SV_COV_STOP  = `SV_COV_STOP; // 1
+localparam int SV_COV_RESET = `SV_COV_RESET; // 2
+localparam int SV_COV_CHECK = `SV_COV_CHECK; // 3
+
+// Scope definition (hierarchy traversal/accumulation type)
+localparam int SV_COV_MODULE = `SV_COV_MODULE; // 10
+localparam int SV_COV_HIER   = `SV_COV_HIER; // 11
+
+// Coverage type identification
+localparam int SV_COV_ASSERTION = `SV_COV_ASSERTION; // 20
+localparam int SV_COV_FSM_STATE = `SV_COV_FSM_STATE; // 21
+localparam int SV_COV_STATEMENT = `SV_COV_STATEMENT; // 22
+localparam int SV_COV_TOGGLE    = `SV_COV_TOGGLE; // 23
+
+// Status results
+localparam int SV_COV_OVERFLOW = `SV_COV_OVERFLOW; // -2
+localparam int SV_COV_ERROR    = `SV_COV_ERROR; // -1
+localparam int SV_COV_NOCOV    = `SV_COV_NOCOV; // 0
+localparam int SV_COV_OK       = `SV_COV_OK; // 1
+localparam int SV_COV_PARTIAL  = `SV_COV_PARTIAL; // 2

--- a/sv-parser-pp/testcases/expected/coverage_constants.sv
+++ b/sv-parser-pp/testcases/expected/coverage_constants.sv
@@ -1,0 +1,26 @@
+// IEEE1800-2017 Clause 40.3.1
+// The following predefined `define macros represent basic real-time coverage
+// capabilities accessible directly from SystemVerilog:
+
+// Coverage control
+localparam int SV_COV_START = 0; // 0
+localparam int SV_COV_STOP  = 1; // 1
+localparam int SV_COV_RESET = 2; // 2
+localparam int SV_COV_CHECK = 3; // 3
+
+// Scope definition (hierarchy traversal/accumulation type)
+localparam int SV_COV_MODULE = 10; // 10
+localparam int SV_COV_HIER   = 11; // 11
+
+// Coverage type identification
+localparam int SV_COV_ASSERTION = 20; // 20
+localparam int SV_COV_FSM_STATE = 21; // 21
+localparam int SV_COV_STATEMENT = 22; // 22
+localparam int SV_COV_TOGGLE    = 23; // 23
+
+// Status results
+localparam int SV_COV_OVERFLOW = -2; // -2
+localparam int SV_COV_ERROR    = -1; // -1
+localparam int SV_COV_NOCOV    = 0; // 0
+localparam int SV_COV_OK       = 1; // 1
+localparam int SV_COV_PARTIAL  = 2; // 2


### PR DESCRIPTION
Noticed a few failing tests here: <https://chipsalliance.github.io/sv-tests-results/>

Pre-populate the `defines` HashMap before any parsing, and before any user-given definitions are inserted. That means these can be overridden without error by the user (backwards compatability).

Quote from the LRM, page 1121:
The following predefined `define macros represent basic real-time coverage capabilities accessible
directly from SystemVerilog:
- Coverage control
  - `` `define SV_COV_START 0 ``
  - `` `define SV_COV_STOP 1 ``
  - `` `define SV_COV_RESET 2 ``
  - `` `define SV_COV_CHECK 3 ``
- Scope definition (hierarchy traversal/accumulation type)
  - `` `define SV_COV_MODULE 10 ``
  - `` `define SV_COV_HIER 11 ``
- Coverage type identification
  - `` `define SV_COV_ASSERTION 20 ``
  - `` `define SV_COV_FSM_STATE 21 ``
  - `` `define SV_COV_STATEMENT 22 ``
  - `` `define SV_COV_TOGGLE 23 ``
- Status results
  - `` `define SV_COV_OVERFLOW -2 ``
  - `` `define SV_COV_ERROR -1 ``
  - `` `define SV_COV_NOCOV 0 ``
  - `` `define SV_COV_OK 1 ``
  - `` `define SV_COV_PARTIAL 2 ``