### PR TITLE
bugfix73 Spelling-only `Assetion` -> `Assertion`

### DIFF
--- a/sv-parser-parser/src/behavioral_statements/assertion_statements.rs
+++ b/sv-parser-parser/src/behavioral_statements/assertion_statements.rs
@@ -19,10 +19,10 @@ pub(crate) fn assertion_item(s: Span) -> IResult<Span, AssertionItem> {
 #[packrat_parser]
 pub(crate) fn deferred_immediate_assertion_item(
     s: Span,
-) -> IResult<Span, DeferredImmediateAssetionItem> {
+) -> IResult<Span, DeferredImmediateAssertionItem> {
     let (s, a) = opt(pair(block_identifier, symbol(":")))(s)?;
     let (s, b) = deferred_immediate_assertion_statement(s)?;
-    Ok((s, DeferredImmediateAssetionItem { nodes: (a, b) }))
+    Ok((s, DeferredImmediateAssertionItem { nodes: (a, b) }))
 }
 
 #[tracable_parser]
@@ -45,13 +45,13 @@ pub(crate) fn procedural_assertion_statement(
 
 #[tracable_parser]
 #[packrat_parser]
-pub(crate) fn immediate_assertion_statement(s: Span) -> IResult<Span, ImmediateAssetionStatement> {
+pub(crate) fn immediate_assertion_statement(s: Span) -> IResult<Span, ImmediateAssertionStatement> {
     alt((
         map(simple_immediate_assertion_statement, |x| {
-            ImmediateAssetionStatement::Simple(Box::new(x))
+            ImmediateAssertionStatement::Simple(Box::new(x))
         }),
         map(deferred_immediate_assertion_statement, |x| {
-            ImmediateAssetionStatement::Deferred(Box::new(x))
+            ImmediateAssertionStatement::Deferred(Box::new(x))
         }),
     ))(s)
 }

--- a/sv-parser-syntaxtree/src/behavioral_statements/assertion_statements.rs
+++ b/sv-parser-syntaxtree/src/behavioral_statements/assertion_statements.rs
@@ -5,11 +5,11 @@ use crate::*;
 #[derive(Clone, Debug, PartialEq, Node)]
 pub enum AssertionItem {
     Concurrent(Box<ConcurrentAssertionItem>),
-    Immediate(Box<DeferredImmediateAssetionItem>),
+    Immediate(Box<DeferredImmediateAssertionItem>),
 }
 
 #[derive(Clone, Debug, PartialEq, Node)]
-pub struct DeferredImmediateAssetionItem {
+pub struct DeferredImmediateAssertionItem {
     pub nodes: (
         Option<(BlockIdentifier, Symbol)>,
         DeferredImmediateAssertionStatement,
@@ -19,12 +19,12 @@ pub struct DeferredImmediateAssetionItem {
 #[derive(Clone, Debug, PartialEq, Node)]
 pub enum ProceduralAssertionStatement {
     Concurrent(Box<ConcurrentAssertionStatement>),
-    Immediate(Box<ImmediateAssetionStatement>),
+    Immediate(Box<ImmediateAssertionStatement>),
     Checker(Box<CheckerInstantiation>),
 }
 
 #[derive(Clone, Debug, PartialEq, Node)]
-pub enum ImmediateAssetionStatement {
+pub enum ImmediateAssertionStatement {
     Simple(Box<SimpleImmediateAssertionStatement>),
     Deferred(Box<DeferredImmediateAssertionStatement>),
 }


### PR DESCRIPTION
As per #73, there are some spelling mistakes.
Found by searching documentation in combination with LRM, while working on svlint (https://github.com/dalance/svlint/pull/195).