### PR TITLE
Improvement: Handle non-UTF8 files 

### DIFF
--- a/sv-parser-error/src/lib.rs
+++ b/sv-parser-error/src/lib.rs
@@ -15,6 +15,9 @@ pub enum Error {
         path: PathBuf,
     },
 
+    #[error("File could not be read as UTF8: {0:?}")]
+    ReadUtf8(Option<PathBuf>),
+
     #[error("Include error")]
     Include {
         #[from]

--- a/sv-parser-error/src/lib.rs
+++ b/sv-parser-error/src/lib.rs
@@ -34,7 +34,7 @@ pub enum Error {
     DefineNotFound(String),
 
     #[error("Define must have argument")]
-    DefineNoArgs,
+    DefineNoArgs(String), // String is the macro identifier.
 
     #[error("Exceed recursive limit")]
     ExceedRecursiveLimit,

--- a/sv-parser-error/src/lib.rs
+++ b/sv-parser-error/src/lib.rs
@@ -16,7 +16,7 @@ pub enum Error {
     },
 
     #[error("File could not be read as UTF8: {0:?}")]
-    ReadUtf8(Option<PathBuf>),
+    ReadUtf8(PathBuf),
 
     #[error("Include error")]
     Include {

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -942,7 +942,7 @@ fn resolve_text_macro_usage<T: AsRef<Path>, U: AsRef<Path>>(
         let mut arg_map = HashMap::new();
 
         if !define.arguments.is_empty() && no_args {
-            return Err(Error::DefineNoArgs);
+            return Err(Error::DefineNoArgs(define.identifier.clone()));
         }
 
         for (i, (arg, default)) in define.arguments.iter().enumerate() {
@@ -1063,6 +1063,22 @@ mod tests {
             ret.text(),
             testfile_contents("expected/escaped_identifier.sv")
         );
+    } // }}}
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn err_DefineNoArgs() { // {{{
+        match preprocess_usualargs("err_DefineNoArgs.sv").unwrap_err() {
+            Error::DefineNoArgs(identifier) => {
+                assert_eq!(
+                    identifier,
+                    String::from("A")
+                );
+            }
+            _ => {
+                panic!("Error::DefineNoArgs not raised.");
+            }
+        };
     } // }}}
 
     #[test]

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -151,7 +151,7 @@ fn preprocess_inner<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
     let mut s = String::new();
 
     if let Err(_) = reader.read_to_string(&mut s) {
-        Err(Error::ReadUtf8(Some(PathBuf::from(path.as_ref()))))
+        Err(Error::ReadUtf8(PathBuf::from(path.as_ref())))
     } else {
         preprocess_str(
             &s,
@@ -1123,10 +1123,10 @@ mod tests {
             Error::ReadUtf8(path) => {
                 assert_eq!(
                     path,
-                    Some(PathBuf::from(format!(
+                    PathBuf::from(format!(
                         "{}/testcases/err_ReadUtf8.sv",
                         env::var("CARGO_MANIFEST_DIR").unwrap(),
-                    )))
+                    ))
                 );
             }
             _ => {

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -1083,6 +1083,22 @@ mod tests {
 
     #[test]
     #[allow(non_snake_case)]
+    fn err_DefineNotFound() { // {{{
+        match preprocess_usualargs("err_DefineNotFound.sv").unwrap_err() {
+            Error::DefineNotFound(identifier) => {
+                assert_eq!(
+                    identifier,
+                    String::from("A")
+                );
+            }
+            _ => {
+                panic!("Error::DefineNotFound not raised.");
+            }
+        };
+    } // }}}
+
+    #[test]
+    #[allow(non_snake_case)]
     fn IEEE18002017_keywords_if2_13642005() { // {{{
         let (ret, _) = preprocess_usualargs("IEEE18002017_keywords_if2_13642005.sv").unwrap();
         assert_eq!(

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -1099,6 +1099,22 @@ mod tests {
 
     #[test]
     #[allow(non_snake_case)]
+    fn err_DefineArgNotFound() { // {{{
+        match preprocess_usualargs("err_DefineArgNotFound.sv").unwrap_err() {
+            Error::DefineArgNotFound(identifier) => {
+                assert_eq!(
+                    identifier,
+                    String::from("c")
+                );
+            }
+            _ => {
+                panic!("Error::DefineArgNotFound not raised.");
+            }
+        };
+    } // }}}
+
+    #[test]
+    #[allow(non_snake_case)]
     fn IEEE18002017_keywords_if2_13642005() { // {{{
         let (ret, _) = preprocess_usualargs("IEEE18002017_keywords_if2_13642005.sv").unwrap();
         assert_eq!(

--- a/sv-parser-pp/testcases/err_DefineArgNotFound.sv
+++ b/sv-parser-pp/testcases/err_DefineArgNotFound.sv
@@ -1,0 +1,5 @@
+/* IEEE1800-2017 Clause 22.5.1 top of page 678
+*/
+`define MACRO1(a=5,b="B",c) $display(a,,b,,c);
+`MACRO1(1) // Macro called without required argument `c`.
+

--- a/sv-parser-pp/testcases/err_DefineNoArgs.sv
+++ b/sv-parser-pp/testcases/err_DefineNoArgs.sv
@@ -1,0 +1,4 @@
+
+`define A(a)
+`A // Macro called without required argument.
+

--- a/sv-parser-pp/testcases/err_DefineNotFound.sv
+++ b/sv-parser-pp/testcases/err_DefineNotFound.sv
@@ -1,0 +1,3 @@
+
+`A // Macro called without definition.
+

--- a/sv-parser-pp/testcases/err_ReadUtf8.sv
+++ b/sv-parser-pp/testcases/err_ReadUtf8.sv
@@ -1,0 +1,4 @@
+// In the next comment, there are non-UTF8 bytes.
+module M;
+// Non-UTF8:XñòóôõöX
+endmodule


### PR DESCRIPTION
Address #78, in prep for comments on https://github.com/dalance/svlint/pull/224.

- Add tests for `Error::DefineNoArgs`, `Error::DefineNotFound`, and `Error::DefineArgNotFound`.
- Extend `Error::DefineNoArgs` with single argument to show which macro requires arguments.
- Add `Error::ReadUtf8`, with a test, for files of invalid UTF-8.
  Tested on sibling branch of svlint.