### PR TITLE
Modify to handle symplink as well as file

### DIFF
--- a/sv-parser-syntaxtree/build.rs
+++ b/sv-parser-syntaxtree/build.rs
@@ -65,7 +65,7 @@ fn main() {
 
     for entry in WalkDir::new("src") {
         let entry = entry.unwrap();
-        if entry.file_type().is_file() {
+        if entry.path().is_file() {
             let f = File::open(entry.path()).unwrap();
             let f = BufReader::new(f);
             let mut hit_node = false;


### PR DESCRIPTION
## Issue

While building rust source with the rules_rust(rust_library or rust_binary) build rule in the bazel build system, I encountered a bug. Bazel creates working directories using symlinks to files, but sv-parser checks if it's a file and ignores it if it's a symlink. so, requires an update to allow sv-parser to handle symlinks.

