### PR TITLE
Fix chained method

### DIFF
--- a/sv-parser-parser/src/expressions/subroutine_calls.rs
+++ b/sv-parser-parser/src/expressions/subroutine_calls.rs
@@ -152,7 +152,7 @@ pub(crate) fn method_call(s: Span) -> IResult<Span, MethodCall> {
     let (s, c) = method_call_body(s)?;
     let mut init_method_call = MethodCall { nodes: (a, b, c) };
 
-    //check for chained method method
+    // check for chained method
     let (s, sub_calls) = many0(pair(symbol("."), method_call_body))(s)?;
     for (dot, body) in sub_calls {
         let fun_sub_call = Primary::FunctionSubroutineCall(Box::new(FunctionSubroutineCall {

--- a/sv-parser-parser/src/tests.rs
+++ b/sv-parser-parser/src/tests.rs
@@ -46,6 +46,13 @@ mod unit {
     use super::*;
 
     #[test]
+    fn test_chained_method_call() {
+        test!(method_call, "variable.method1().method2()", Ok((_, _)));
+        test!(method_call, "variable.member.method2()", Ok((_, _)));
+        test!(method_call, "variable.method1().member", Ok((_, _)));
+    }
+
+    #[test]
     fn test_pulldown_strength() {
         test!(pulldown_strength, "(supply0, strong1)", Ok((_, _)));
         test!(pulldown_strength, "(pull1, weak0)", Ok((_, _)));


### PR DESCRIPTION
This PR fixes #91.
After investigating my examples, I noticed the `method_call` parser consumes the first method call (`variable.method1()`), leaving the other parsers to deal with a method call body on its own (`.method2()`) which obviously doesn't match anything.
Instead, `variable.method1()` should be recognized as a `MethodCallRoot` and matched with its `MethodCallBody`: `method2()`

Note that in the 3rd test I added, `member` was meant as a class member but is parsed as a method call. As far as I know, however, without more context (ie: the return type of `method1()` and its definition), we cannot rule out one possibility in favor of the other.