### PR TITLE
fix event control asterisk to accept whitespace between @ and *

### DIFF
--- a/sv-parser-parser/src/behavioral_statements/timing_control_statements.rs
+++ b/sv-parser-parser/src/behavioral_statements/timing_control_statements.rs
@@ -99,10 +99,11 @@ pub(crate) fn event_control_event_expression(s: Span) -> IResult<Span, EventCont
 #[tracable_parser]
 #[packrat_parser]
 pub(crate) fn event_control_asterisk(s: Span) -> IResult<Span, EventControl> {
-    let (s, a) = symbol("@*")(s)?;
+    let (s, a) = symbol("@")(s)?;
+    let (s, b) = symbol("*")(s)?;
     Ok((
         s,
-        EventControl::Asterisk(Box::new(EventControlAsterisk { nodes: (a,) })),
+        EventControl::Asterisk(Box::new(EventControlAsterisk { nodes: (a, b) })),
     ))
 }
 

--- a/sv-parser-parser/src/tests.rs
+++ b/sv-parser-parser/src/tests.rs
@@ -317,6 +317,13 @@ mod unit {
     }
 
     #[test]
+    fn test_event_control_asterisk() {
+        test!(event_control_asterisk, "@*", Ok((_, _)));
+        test!(event_control_asterisk, "@ *", Ok((_, _)));
+        test!(event_control_asterisk, "@      *", Ok((_, _)));
+    }
+
+    #[test]
     fn test_expression() {
         test!(expression, "(!a ? 0 : !b : 1 : c ? 0 : 1)", Ok((_, _)));
     }

--- a/sv-parser-syntaxtree/src/behavioral_statements/timing_control_statements.rs
+++ b/sv-parser-syntaxtree/src/behavioral_statements/timing_control_statements.rs
@@ -56,7 +56,7 @@ pub struct EventControlEventExpression {
 
 #[derive(Clone, Debug, PartialEq, Node)]
 pub struct EventControlAsterisk {
-    pub nodes: (Symbol,),
+    pub nodes: (Symbol, Symbol),
 }
 
 #[derive(Clone, Debug, PartialEq, Node)]


### PR DESCRIPTION
This is a fix for EventControlAsterisk to have 2 symbols @ and *. Most compilers seems to accept a whitespace between @ and *. This module was not being parsed with sv-parser. While others like https://sv-lang.com/explore/ and verilator considered it valid.

```verilog
module test;
    reg a, b;
    reg out; 

    always @ * begin
        out = a & b;
    end

    always @* begin
        out = a | b;
    end
    initial begin
        // Initialize inputs
        a = 0; b = 0;
        #10; a = 1; b = 0;
        #10; a = 0; b = 1;
        #10; a = 1; b = 1;
        #10; $finish;
    end

    initial begin
        $monitor("At time %0t: a = %0b, b = %0b, out = %0b", $time, a, b, out);
    end
endmodule
```

