### PR TITLE
preparser: adding 2 optional compiler directives delay_mode_path , delay_mode_distributed

### DIFF
--- a/sv-parser-parser/src/general/compiler_directives.rs
+++ b/sv-parser-parser/src/general/compiler_directives.rs
@@ -59,6 +59,18 @@ pub(crate) fn compiler_directive(s: Span) -> IResult<Span, CompilerDirective> {
         map(text_macro_usage, |x| {
             CompilerDirective::TextMacroUsage(Box::new(x))
         }),
+        map(delay_mode_distributed_compiler_directive, |x| {
+            CompilerDirective::DelayModeDistributedDirective(Box::new(x))
+        }),
+        map(delay_mode_path_compiler_directive, |x| {
+            CompilerDirective::DelayModePathDirective(Box::new(x))
+        }),
+        // map(delay_mode_unit_compiler_directive, |x| {
+        //     CompilerDirective::DelayModeUnitDirective(Box::new(x))
+        // }),
+        // map(delay_mode_zero_compiler_directive, |x| {
+        //     CompilerDirective::DelayModeZeroDirective(Box::new(x))
+        // }),
     ))(s);
     end_directive();
     ret
@@ -118,6 +130,18 @@ pub(crate) fn compiler_directive_without_resetall(s: Span) -> IResult<Span, Comp
         map(text_macro_usage, |x| {
             CompilerDirective::TextMacroUsage(Box::new(x))
         }),
+        map(delay_mode_distributed_compiler_directive, |x| {
+            CompilerDirective::DelayModeDistributedDirective(Box::new(x))
+        }),
+        map(delay_mode_path_compiler_directive, |x| {
+            CompilerDirective::DelayModePathDirective(Box::new(x))
+        }),
+        // map(delay_mode_unit_compiler_directive, |x| {
+        //     CompilerDirective::DelayModeUnitDirective(Box::new(x))
+        // }),
+        // map(delay_mode_zero_compiler_directive, |x| {
+        //     CompilerDirective::DelayModeZeroDirective(Box::new(x))
+        // }),
     ))(s);
     end_directive();
     ret
@@ -873,3 +897,44 @@ pub(crate) fn endkeywords_directive(s: Span) -> IResult<Span, EndkeywordsDirecti
     end_keywords();
     Ok((s, EndkeywordsDirective { nodes: (a, b) }))
 }
+
+#[tracable_parser]
+#[packrat_parser]
+pub(crate) fn delay_mode_distributed_compiler_directive(
+    s: Span,
+) -> IResult<Span, DelayModeDistributedDirective> {
+    let (s, a) = symbol("`")(s)?;
+    let (s, b) = keyword("delay_mode_distributed")(s)?;
+    Ok((s, DelayModeDistributedDirective { nodes: (a, b) }))
+}
+
+#[tracable_parser]
+#[packrat_parser]
+pub(crate) fn delay_mode_path_compiler_directive(
+    s: Span,
+) -> IResult<Span, DelayModePathDirective> {
+    let (s, a) = symbol("`")(s)?;
+    let (s, b) = keyword("delay_mode_path")(s)?;
+    Ok((s, DelayModePathDirective { nodes: (a, b) }))
+}
+
+//TODO: bring back once nom issue is solved
+// #[tracable_parser]
+// #[packrat_parser]
+// pub(crate) fn delay_mode_unit_compiler_directive(
+//     s: Span,
+// ) -> IResult<Span, DelayModeUnitDirective> {
+//     let (s, a) = symbol("`")(s)?;
+//     let (s, b) = keyword("delay_mode_unit")(s)?;
+//     Ok((s, DelayModeUnitDirective { nodes: (a, b) }))
+// }
+
+// #[tracable_parser]
+// #[packrat_parser]
+// pub(crate) fn delay_mode_zero_compiler_directive(
+//     s: Span,
+// ) -> IResult<Span, DelayModeZeroDirective> {
+//     let (s, a) = symbol("`")(s)?;
+//     let (s, b) = keyword("delay_mode_zero")(s)?;
+//     Ok((s, DelayModeZeroDirective { nodes: (a, b) }))
+// }

--- a/sv-parser-parser/src/keywords.rs
+++ b/sv-parser-parser/src/keywords.rs
@@ -1466,4 +1466,8 @@ pub(crate) const KEYWORDS_DIRECTIVE: &[&str] = &[
     "unconnected_drive",
     "undef",
     "undefineall",
+    "delay_mode_distributed",
+    "delay_mode_path",
+    // "delay_mode_unit",
+    // "delay_mode_zero"
 ];

--- a/sv-parser-pp/src/preprocess.rs
+++ b/sv-parser-pp/src/preprocess.rs
@@ -406,6 +406,42 @@ pub fn preprocess_str<T: AsRef<Path>, U: AsRef<Path>, V: BuildHasher>(
             NodeEvent::Leave(RefNode::EndcelldefineDriveCompilerDirective(_)) => {
                 skip_whitespace = false;
             }
+            NodeEvent::Enter(RefNode::DelayModeDistributedDirective(x)) => {
+                let locate: Locate = x.try_into().unwrap();
+                let range = Range::new(locate.offset, locate.offset + locate.len);
+                ret.push(locate.str(&s), Some((path.as_ref(), range)));
+                skip_whitespace = true;
+            }
+            NodeEvent::Leave(RefNode::DelayModeDistributedDirective(_)) => {
+                skip_whitespace = false;
+            }
+            NodeEvent::Enter(RefNode::DelayModePathDirective(x)) => {
+                let locate: Locate = x.try_into().unwrap();
+                let range = Range::new(locate.offset, locate.offset + locate.len);
+                ret.push(locate.str(&s), Some((path.as_ref(), range)));
+                skip_whitespace = true;
+            }
+            NodeEvent::Leave(RefNode::DelayModePathDirective(_)) => {
+                skip_whitespace = false;
+            }
+            // NodeEvent::Enter(RefNode::DelayModeUnitDirective(x)) => {
+            //     let locate: Locate = x.try_into().unwrap();
+            //     let range = Range::new(locate.offset, locate.offset + locate.len);
+            //     ret.push(locate.str(&s), Some((path.as_ref(), range)));
+            //     skip_whitespace = true;
+            // }
+            // NodeEvent::Leave(RefNode::DelayModeUnitDirective(_)) => {
+            //     skip_whitespace = false;
+            // }
+            // NodeEvent::Enter(RefNode::DelayModeZeroDirective(x)) => {
+            //     let locate: Locate = x.try_into().unwrap();
+            //     let range = Range::new(locate.offset, locate.offset + locate.len);
+            //     ret.push(locate.str(&s), Some((path.as_ref(), range)));
+            //     skip_whitespace = true;
+            // }
+            // NodeEvent::Leave(RefNode::DelayModeZeroDirective(_)) => {
+            //     skip_whitespace = false;
+            // }
             NodeEvent::Enter(RefNode::Pragma(x)) => {
                 let locate: Locate = x.try_into().unwrap();
                 let range = Range::new(locate.offset, locate.offset + locate.len);
@@ -1639,4 +1675,12 @@ mod tests {
             testfile_contents("expected/undefineall.sv")
         );
     } // }}}
+
+    #[test]
+    fn annex_e(){
+        match preprocess_usualargs("IEEE18002017_AnnexE_delaydirectives.sv"){
+            Ok(_x) => (),
+            Err(x) => panic!("failed with {}",x)
+        }
+    }
 }

--- a/sv-parser-pp/testcases/IEEE18002017_AnnexE_delaydirectives.sv
+++ b/sv-parser-pp/testcases/IEEE18002017_AnnexE_delaydirectives.sv
@@ -1,0 +1,11 @@
+/*
+The compiler directives described in this annex are for informative purposes only and are not part of this
+standard.
+This annex describes additional compiler directives as companions to the compiler directives described in
+Clause 22. The compiler directives described in this annex may not be available in all implementations of
+SystemVerilog. The following compiler directives are described in this annex:
+*/
+
+
+`delay_mode_distributed //[E.4]
+`delay_mode_path //[E.5]

--- a/sv-parser-syntaxtree/src/general/compiler_directives.rs
+++ b/sv-parser-syntaxtree/src/general/compiler_directives.rs
@@ -22,6 +22,10 @@ pub enum CompilerDirective {
     PositionCompilerDirective(Box<PositionCompilerDirective>),
     KeywordsDirective(Box<KeywordsDirective>),
     EndkeywordsDirective(Box<EndkeywordsDirective>),
+    DelayModeDistributedDirective(Box<DelayModeDistributedDirective>),
+    DelayModePathDirective(Box<DelayModePathDirective>),
+    // DelayModeUnitDirective(Box<DelayModeUnitDirective>),
+    // DelayModeZeroDirective(Box<DelayModeZeroDirective>)
 }
 
 #[derive(Clone, Debug, PartialEq, Node)]
@@ -303,5 +307,26 @@ pub struct VersionSpecifier {
 
 #[derive(Clone, Debug, PartialEq, Node)]
 pub struct EndkeywordsDirective {
+    pub nodes: (Symbol, Keyword),
+}
+
+
+#[derive(Clone, Debug, PartialEq, Node)]
+pub struct DelayModeDistributedDirective {
+    pub nodes: (Symbol, Keyword),
+}
+
+#[derive(Clone, Debug, PartialEq, Node)]
+pub struct DelayModePathDirective {
+    pub nodes: (Symbol, Keyword),
+}
+
+#[derive(Clone, Debug, PartialEq, Node)]
+pub struct DelayModeUnitDirective {
+    pub nodes: (Symbol, Keyword),
+}
+
+#[derive(Clone, Debug, PartialEq, Node)]
+pub struct DelayModeZeroDirective {
     pub nodes: (Symbol, Keyword),
 }


### PR DESCRIPTION
These 2 compiler directives are defined in Annex E of the 1800-2017

I ran into this while attempting to parse some stdcell libraries.
I unfortunately can't seem to add all  of the annex directives as the `nom` crate seems to have an issue
digging deeper when attempting to use the alt function in `sv-parser-parser/src/general/compiler_directives.rs:L9`
the nom alt function supports only up to 21 elements, placing all of them breaks this.

regardless, without these two directives I can't parse said Verilog.
