### PR TITLE
Fix sequence with parameter as cycle delay

### DIFF
--- a/sv-parser-parser/src/expressions/primaries.rs
+++ b/sv-parser-parser/src/expressions/primaries.rs
@@ -43,6 +43,41 @@ pub(crate) fn constant_primary(s: Span) -> IResult<Span, ConstantPrimary> {
 
 #[tracable_parser]
 #[packrat_parser]
+pub(crate) fn constant_primary_no_function(s: Span) -> IResult<Span, ConstantPrimary> {
+    alt((
+        // BNF-WA
+        map(keyword("$"), |x| ConstantPrimary::Dollar(Box::new(x))),
+        map(keyword("null"), |x| ConstantPrimary::Null(Box::new(x))),
+        map(constant_assignment_pattern_expression, |x| {
+            ConstantPrimary::ConstantAssignmentPatternExpression(Box::new(x))
+        }),
+        map(constant_cast, |x| {
+            ConstantPrimary::ConstantCast(Box::new(x))
+        }),
+        map(primary_literal, |x| {
+            ConstantPrimary::PrimaryLiteral(Box::new(x))
+        }),
+        constant_primary_mintypmax_expression,
+        constant_primary_ps_parameter,
+        constant_primary_specparam,
+        map(genvar_identifier, |x| {
+            ConstantPrimary::GenvarIdentifier(Box::new(x))
+        }),
+        constant_primary_formal_port,
+        constant_primary_enum,
+        constant_primary_concatenation,
+        constant_primary_multiple_concatenation,
+        map(constant_let_expression, |x| {
+            ConstantPrimary::ConstantLetExpression(Box::new(x))
+        }),
+        map(type_reference, |x| {
+            ConstantPrimary::TypeReference(Box::new(x))
+        }),
+    ))(s)
+}
+
+#[tracable_parser]
+#[packrat_parser]
 pub(crate) fn constant_primary_without_cast(s: Span) -> IResult<Span, ConstantPrimary> {
     alt((
         // BNF-WA

--- a/sv-parser-parser/src/tests.rs
+++ b/sv-parser-parser/src/tests.rs
@@ -15906,6 +15906,11 @@ mod spec {
     }
 
     #[test]
+    fn test_sequence_constant_primary_param() {
+        test!(sequence_expr, "##MY_PARAM (in2 == in3)", Ok((_, _)));
+    }
+
+    #[test]
     fn clause36() {
         test!(
             many1(module_item),


### PR DESCRIPTION
This SystemVerilog code causes the parser to return an error:

```verilog
property my_prop;
    in1
|-> 
    ##MY_PARAM (in2 == in3);
endproperty
```

Mainly because of ##MY_PARAM (in2 == in3). Removing the parenthesis around in2 == in3 makes it work. The reason from what I observed is that sv-parser first tries to parse MY_PARAM into a constant function call which takes (in2 == in3) as an argument. Then causes an error because there is no sequence expression after the cycle delay.

I attempted to fix it by trying a parser for constant primary without parsing constant function, if the original parser failed.