### PR TITLE
Fix: allow empty default argument in macro definition

### DIFF
--- a/sv-parser-parser/src/general/compiler_directives.rs
+++ b/sv-parser-parser/src/general/compiler_directives.rs
@@ -293,7 +293,7 @@ pub(crate) fn macro_text(s: Span) -> IResult<Span, MacroText> {
 #[tracable_parser]
 #[packrat_parser]
 pub(crate) fn default_text(s: Span) -> IResult<Span, DefaultText> {
-    let (s, a) = define_argument(s)?;
+    let (s, a) = alt((define_argument, map(tag(""), |x| x)))(s)?;
     Ok((
         s,
         DefaultText {

--- a/sv-parser-pp/testcases/expected/macro_default_empty.sv
+++ b/sv-parser-pp/testcases/expected/macro_default_empty.sv
@@ -1,0 +1,13 @@
+// IEEE 1800-2017 Clause 22.5 `define, `undef, and `undefineall
+// The directive `define allows formal arguments to have default values.
+// The default value may be an empty token sequence.
+// This test verifies that `define M(a=)` and `define M(a=, b=)` are accepted
+// and expand as expected without errors.
+`define LOGIC(name, prefix=) logic prefix``name;
+`define REAL(name, prefix=, suffix=) real prefix``name``suffix;
+module test;
+  logic signal;
+  logic my_signal;
+  real analog;
+  real my_analog$real;
+endmodule

--- a/sv-parser-pp/testcases/macro_default_empty.sv
+++ b/sv-parser-pp/testcases/macro_default_empty.sv
@@ -1,0 +1,13 @@
+// IEEE 1800-2017 Clause 22.5 `define, `undef, and `undefineall
+// The directive `define allows formal arguments to have default values.
+// The default value may be an empty token sequence.
+// This test verifies that `define M(a=)` and `define M(a=, b=)` are accepted
+// and expand as expected without errors.
+`define LOGIC(name, prefix=) logic prefix``name;
+`define REAL(name, prefix=, suffix=) real prefix``name``suffix;
+module test;
+  `LOGIC(signal)
+  `LOGIC(signal, my_)
+  `REAL(analog)
+  `REAL(analog, my_, $real)
+endmodule


### PR DESCRIPTION
Fixes #116

Previously, macros like the following expanded incorrectly:
```systemverilog
`define REAL(name, suffix=) real name``suffix;
```
This change updates the parser to correctly handle empty defaults.