### PR TITLE
Fix: reject implicit data types in data_declaration

### DIFF
--- a/sv-parser-parser/src/declarations/type_declarations.rs
+++ b/sv-parser-parser/src/declarations/type_declarations.rs
@@ -25,7 +25,13 @@ pub(crate) fn data_declaration_variable(s: Span) -> IResult<Span, DataDeclaratio
     let (s, a) = opt(r#const)(s)?;
     let (s, b) = opt(var)(s)?;
     let (s, c) = opt(lifetime)(s)?;
-    let (s, d) = data_type_or_implicit_data_declaration_variable(s)?;
+    let (s, d) = (verify(
+        data_type_or_implicit_data_declaration_variable,
+        |d| match d {
+            DataTypeOrImplicit::DataType(_) => true,
+            DataTypeOrImplicit::ImplicitDataType(_) => b.is_some(),
+        },
+    ))(s)?;
     let (s, e) = list_of_variable_decl_assignments(s)?;
     let (s, f) = symbol(";")(s)?;
     Ok((


### PR DESCRIPTION
This PR fixes #118.

## Summary

This change ensures that implicit data types in `data_declaration` are rejected unless the `var` keyword is explicitly used.  
This aligns the parser behavior with the SystemVerilog standard and prevents ambiguous parsing inside procedural blocks.

## Changes

- Add `verify` logic to reject implicit data types in `data_declaration_variable` when `var` is not used.
- Add unit tests validating the updated behavior.
- Update several spec tests to reflect correct SystemVerilog parsing rules.

## Notes on Spec Tests

Some spec tests were previously validating the parsing of procedural assignments as `module_item`s.  
However, such statements are illegal at the module scope according to the SystemVerilog LRM.

This incorrect behavior was caused by treating identifier-leading procedural assignments as implicit declarations.

This PR corrects that behavior, and the affected spec tests have been updated accordingly.