### PR TITLE
 Fix parser failure for `inside` expression in module-level if generate construct

### DIFF
--- a/sv-parser-parser/src/expressions/expressions.rs
+++ b/sv-parser-parser/src/expressions/expressions.rs
@@ -78,9 +78,15 @@ pub(crate) fn expression_or_cond_pattern_ternary(
 #[packrat_parser]
 pub(crate) fn constant_expression(s: Span) -> IResult<Span, ConstantExpression> {
     alt((
+        map(terminated(constant_primary, peek(one_of(",();}:"))), |x| {
+            ConstantExpression::ConstantPrimary(Box::new(x))
+        }),
         constant_expression_ternary,
         constant_expression_binary,
         constant_expression_unary,
+        map(constant_inside_expression, |x| {
+            ConstantExpression::Inside(Box::new(x))
+        }),
         map(constant_primary, |x| {
             ConstantExpression::ConstantPrimary(Box::new(x))
         }),
@@ -131,6 +137,16 @@ pub(crate) fn constant_expression_ternary(s: Span) -> IResult<Span, ConstantExpr
             nodes: (a, b, c, d, e, f),
         })),
     ))
+}
+
+#[recursive_parser]
+#[tracable_parser]
+#[packrat_parser]
+pub(crate) fn constant_inside_expression(s: Span) -> IResult<Span, ConstantInsideExpression> {
+    let (s, a) = constant_expression(s)?;
+    let (s, b) = keyword("inside")(s)?;
+    let (s, c) = brace(open_range_list)(s)?;
+    Ok((s, ConstantInsideExpression { nodes: (a, b, c) }))
 }
 
 #[tracable_parser]

--- a/sv-parser-parser/src/tests.rs
+++ b/sv-parser-parser/src/tests.rs
@@ -5062,6 +5062,21 @@ mod spec {
                 assign r=3'bz11 inside {3'b1?1, 3'b011}; // r = 1'bx"##,
             Ok((_, _))
         );
+        // Bug trigger: inside expression in module-level if statement (without generate keyword)
+        // Fails at "inside" keyword - parser cannot handle "if (x inside {a, b}) begin" at module level
+        test!(
+            many1(module_item),
+            r##"module a;
+                  typedef enum logic {
+                    SwAccessRW  = 0,
+                    SwAccessRO  = 1
+                  } sw_access_e;
+                  parameter sw_access_e SwAccess = SwAccessRW;
+                  wire x;
+                  if (SwAccess inside {SwAccessRW, SwAccessRO});
+                endmodule"##,
+            Ok((_, _))
+        );
         test!(
             many1(module_item),
             r##"initial begin

--- a/sv-parser-syntaxtree/src/expressions/expressions.rs
+++ b/sv-parser-syntaxtree/src/expressions/expressions.rs
@@ -36,6 +36,7 @@ pub enum ConstantExpression {
     Unary(Box<ConstantExpressionUnary>),
     Binary(Box<ConstantExpressionBinary>),
     Ternary(Box<ConstantExpressionTernary>),
+    Inside(Box<ConstantInsideExpression>),
 }
 
 #[derive(Clone, Debug, PartialEq, Node)]
@@ -63,6 +64,11 @@ pub struct ConstantExpressionTernary {
         Symbol,
         ConstantExpression,
     ),
+}
+
+#[derive(Clone, Debug, PartialEq, Node)]
+pub struct ConstantInsideExpression {
+    pub nodes: (ConstantExpression, Keyword, Brace<OpenRangeList>),
 }
 
 #[derive(Clone, Debug, PartialEq, Node)]


### PR DESCRIPTION
Fix #122 

## Changes 

- Added `constant_inside_expression` as a new variant of `constant_expression`.
- Test case was already present in `sv-parser-parser/src/tests.rs` at line 5067.
